### PR TITLE
feat: 카프카 컨슈머를 통해 발행회사 알림 관련 메시지를 전달받고 slack에 전달하는 기능 구현

### DIFF
--- a/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/model/dto/NewIssuerMessage.java
+++ b/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/model/dto/NewIssuerMessage.java
@@ -1,0 +1,26 @@
+package com.wl2c.elswherenotificationservice.domain.slack.model.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class NewIssuerMessage {
+
+    @NotNull
+    private String productName;
+
+    @NotNull
+    private String issuer;
+
+    @Builder
+    private NewIssuerMessage(String productName,
+                             String issuer) {
+        this.productName = productName;
+        this.issuer = issuer;
+    }
+}

--- a/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/service/NewIssuerMessageReceiver.java
+++ b/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/service/NewIssuerMessageReceiver.java
@@ -1,0 +1,46 @@
+package com.wl2c.elswherenotificationservice.domain.slack.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wl2c.elswherenotificationservice.client.slack.api.SlackClient;
+import com.wl2c.elswherenotificationservice.client.slack.dto.RequestMessageDto;
+import com.wl2c.elswherenotificationservice.domain.slack.model.dto.NewIssuerMessage;
+import com.wl2c.elswherenotificationservice.domain.slack.model.dto.NewTickerMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NewIssuerMessageReceiver {
+
+    private final SlackClient slackClient;
+
+    @KafkaListener(topics = "new-issuer-alert", groupId = "new-issuer-alert-consumer", containerFactory = "kafkaConsumerContainerFactory")
+    public void receive(String stringMessage) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        NewIssuerMessage newIssuerMessage = objectMapper.readValue(stringMessage, NewIssuerMessage.class);
+        log.info("new-ticker-alert Message Consumed : " + stringMessage);
+
+        ResponseEntity<String> response = slackClient.sendAlert(createMessage(newIssuerMessage));
+        log.info("new-ticker-alert Response : " + response.getStatusCode());
+    }
+
+    private RequestMessageDto createMessage(NewIssuerMessage newIssuerMessage) {
+        String stringBuilder = "새로운 발행회사 정보 반영 필요\n" +
+                "상품명 : " +
+                newIssuerMessage.getProductName() +
+                "\n\n" +
+                "발행회사 : " +
+                newIssuerMessage.getIssuer();
+
+        return new RequestMessageDto(stringBuilder);
+    }
+}


### PR DESCRIPTION
## Issue 번호
#7 

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- Kafka 메시지를 받고 slack에 전달하기 위한 NewIssuerMessageReceiver 구현
