### PR TITLE
feat: 카프카 컨슈머를 통해 정정신고 알림 관련 메시지를 전달받고 slack에 전달하는 기능 구현

### DIFF
--- a/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/model/dto/ProspectusCorrectionReportMessage.java
+++ b/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/model/dto/ProspectusCorrectionReportMessage.java
@@ -1,0 +1,26 @@
+package com.wl2c.elswherenotificationservice.domain.slack.model.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class ProspectusCorrectionReportMessage {
+
+    @NotNull
+    private String productName;
+
+    @NotNull
+    private String prospectusLink;
+
+    @Builder
+    private ProspectusCorrectionReportMessage(String productName,
+                                              String prospectusLink) {
+        this.productName = productName;
+        this.prospectusLink = prospectusLink;
+    }
+}

--- a/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/service/ProspectusCorrectionReportMessageReceiver.java
+++ b/src/main/java/com/wl2c/elswherenotificationservice/domain/slack/service/ProspectusCorrectionReportMessageReceiver.java
@@ -1,0 +1,46 @@
+package com.wl2c.elswherenotificationservice.domain.slack.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wl2c.elswherenotificationservice.client.slack.api.SlackClient;
+import com.wl2c.elswherenotificationservice.client.slack.dto.RequestMessageDto;
+import com.wl2c.elswherenotificationservice.domain.slack.model.dto.NewIssuerMessage;
+import com.wl2c.elswherenotificationservice.domain.slack.model.dto.ProspectusCorrectionReportMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProspectusCorrectionReportMessageReceiver {
+
+    private final SlackClient slackClient;
+
+    @KafkaListener(topics = "prospectus-correction-report-alert", groupId = "prospectus-correction-report-alert-consumer", containerFactory = "kafkaConsumerContainerFactory")
+    public void receive(String stringMessage) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+       ProspectusCorrectionReportMessage prospectusCorrectionReportMessage = objectMapper.readValue(stringMessage, ProspectusCorrectionReportMessage.class);
+        log.info("prospectus-correction-report-alert Message Consumed : " + stringMessage);
+
+        ResponseEntity<String> response = slackClient.sendAlert(createMessage(prospectusCorrectionReportMessage));
+        log.info("prospectus-correction-report-alert Response : " + response.getStatusCode());
+    }
+
+    private RequestMessageDto createMessage(ProspectusCorrectionReportMessage prospectusCorrectionReportMessage) {
+        String stringBuilder = "투자설명서 정정신고한 상품\n" +
+                "상품명 : " +
+                prospectusCorrectionReportMessage.getProductName() +
+                "\n\n" +
+                "투자설명서 링크 : " +
+                prospectusCorrectionReportMessage.getProspectusLink();
+
+        return new RequestMessageDto(stringBuilder);
+    }
+}


### PR DESCRIPTION
## Issue 번호
#10 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- 카프카 컨슈머를 통해 정정신고 알림 관련 메시지를 전달받고 slack에 전달하는 기능 구현
